### PR TITLE
Add missing header on BerTlvUtil and fix possible write past the end …

### DIFF
--- a/src/main/BerTlvUtil.h
+++ b/src/main/BerTlvUtil.h
@@ -14,7 +14,6 @@
 
 #include <map>
 #include <vector>
-#include <cstdint>
 
  /* Core */
 #include "KeypleUtilExport.h"

--- a/src/main/BerTlvUtil.h
+++ b/src/main/BerTlvUtil.h
@@ -14,6 +14,7 @@
 
 #include <map>
 #include <vector>
+#include <cstdint>
 
  /* Core */
 #include "KeypleUtilExport.h"

--- a/src/main/cpp/Logger.cpp
+++ b/src/main/cpp/Logger.cpp
@@ -39,7 +39,7 @@ const std::string Logger::getCurrentTimestamp()
     using std::chrono::system_clock;
     auto currentTime = std::chrono::system_clock::now();
     char buffer1[21];
-    char buffer2[26];
+    char buffer2[25];
 
     auto transformed = currentTime.time_since_epoch().count() / 1000000;
     auto millis = transformed % 1000;

--- a/src/main/cpp/Logger.cpp
+++ b/src/main/cpp/Logger.cpp
@@ -39,7 +39,7 @@ const std::string Logger::getCurrentTimestamp()
     using std::chrono::system_clock;
     auto currentTime = std::chrono::system_clock::now();
     char buffer1[21];
-    char buffer2[25];
+    char buffer2[26];
 
     auto transformed = currentTime.time_since_epoch().count() / 1000000;
     auto millis = transformed % 1000;


### PR DESCRIPTION
-Add missing header on BerTlvUtil and fix possible write past the end of the destination

Signed-off-by: Fabio Araujo [fabio.ara@gmail.com](mailto:fabio.ara@gmail.com)